### PR TITLE
replace "pnpm buildrun"

### DIFF
--- a/docs/codebase/setup/setup.md
+++ b/docs/codebase/setup/setup.md
@@ -74,7 +74,6 @@ You can read more on how this config file works at [Configuration Info](./config
 ### 7. Run!
 
 ```
-pnpm build
 pnpm start
 ```
 

--- a/docs/codebase/setup/setup.md
+++ b/docs/codebase/setup/setup.md
@@ -74,7 +74,8 @@ You can read more on how this config file works at [Configuration Info](./config
 ### 7. Run!
 
 ```
-pnpm buildrun
+pnpm build
+pnpm start
 ```
 
 This will build the server TypeScript into JS under `/js`,


### PR DESCRIPTION
Buildrun does not exist, instead the user should build then start using pnpm.